### PR TITLE
Expand negative grep match for any error for lib scans.

### DIFF
--- a/scan/base.go
+++ b/scan/base.go
@@ -546,8 +546,8 @@ func (l *base) scanLibraries() (err error) {
 		}
 
 		// delete last "-o "
-		// find / -name "*package-lock.json" -o -name "*yarn.lock" ... 2>&1 | grep -v "Permission denied"
-		cmd := fmt.Sprintf(`find / ` + findopt[:len(findopt)-3] + ` 2>&1 | grep -v "Permission denied"`)
+		// find / -name "*package-lock.json" -o -name "*yarn.lock" ... 2>&1 | grep -v "find: "
+		cmd := fmt.Sprintf(`find / ` + findopt[:len(findopt)-3] + ` 2>&1 | grep -v "find: "`)
 		r := exec(l.ServerInfo, cmd, noSudo)
 		if r.ExitStatus != 0 && r.ExitStatus != 1 {
 			return xerrors.Errorf("Failed to find lock files")


### PR DESCRIPTION
Fixes future-architect/vuls#1055.

When find throws an error, it prefixes an error with the utility name,
(`find` by default), the quoted path where find encountered the error,
and the specific error message.

As it stands now, vuls only filters out the 'Permission Denied' message.
Informal testing in a Ubuntu system found other errors from the procfs
pseudo-filesystem. So this fix will filter out all error messages, as find
is only used to lock for language runtime dependency lockfiles, and
nothing else.


If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

